### PR TITLE
Add badges into README about license and packagist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Build Status](https://travis-ci.org/doctrine/migrations.svg)](https://travis-ci.org/doctrine/migrations)
 [![Code Coverage](https://codecov.io/gh/doctrine/migrations/branch/master/graph/badge.svg)](https://codecov.io/gh/doctrine/migrations/branch/master)
+[![Packagist Downloads](https://img.shields.io/packagist/dm/doctrine/migrations)](https://packagist.org/packages/doctrine/migrations)
+[![Packagist Version](https://img.shields.io/packagist/v/doctrine/migrations)](https://packagist.org/packages/doctrine/migrations)
+[![GitHub license](https://img.shields.io/github/license/doctrine/migrations)](https://github.com/doctrine/migrations/blob/master/LICENSE)
 
 ## Documentation
 


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

This PR adds multiple badges into the README. Badges are provided by http://shields.io/ and rely on data sources provided by GitHub and Packagist

Badges are really beautiful 🤩 but also can provide useful informations for people quickly browsing GitHub repositories.
